### PR TITLE
Fix isClassic

### DIFF
--- a/packages/yarn-workspaces-list/src/yarn-classic.ts
+++ b/packages/yarn-workspaces-list/src/yarn-classic.ts
@@ -13,7 +13,7 @@ export async function isClassic(options: CliOptions = {}): Promise<boolean> {
   const { cwd = process.cwd() } = options;
   const { stdout } = await exec(`yarn --version`, { cwd });
 
-  return /1\./.test(stdout);
+  return stdout.startsWith('1.');
 }
 
 interface JsonLine {


### PR DESCRIPTION
The current source version of yarn berry (3.0.1-rc.1.git.20210805.hash-85bd4f58) was being detected as version 1