### PR TITLE
fix(yarn-workspaces-list): regexp to detect if yarn version is classic

### DIFF
--- a/packages/yarn-workspaces-list/src/yarn-berry.ts
+++ b/packages/yarn-workspaces-list/src/yarn-berry.ts
@@ -19,7 +19,7 @@ export async function isBerry(options: CliOptions = {}): Promise<boolean> {
   const { cwd = process.cwd() } = options;
   const { stdout } = await exec(`yarn --version`, { cwd });
 
-  return /2\./.test(stdout);
+  return /^2\.|^3\./.test(stdout);
 }
 
 export async function list(options: CliOptions = {}): Promise<Workspace[]> {

--- a/packages/yarn-workspaces-list/src/yarn-classic.ts
+++ b/packages/yarn-workspaces-list/src/yarn-classic.ts
@@ -13,7 +13,7 @@ export async function isClassic(options: CliOptions = {}): Promise<boolean> {
   const { cwd = process.cwd() } = options;
   const { stdout } = await exec(`yarn --version`, { cwd });
 
-  return /1\./.test(stdout);
+  return /^1\./.test(stdout);
 }
 
 interface JsonLine {


### PR DESCRIPTION
Hi @timhall! Thank you for your work.

This PR fixes an issue when yarn 3.1.0 is incorrectly considered a classic version.

I updated yarn to 3.1.0 recently and met such error trying to build a project:

```
Error: Command failed: yarn --json workspaces info

    at ChildProcess.exithandler (node:child_process:397:12)
    at ChildProcess.emit (node:events:394:28)
    at maybeClose (node:internal/child_process:1067:16)
    at Socket.<anonymous> (node:internal/child_process:453:11)
    at Socket.emit (node:events:394:28)
    at Pipe.<anonymous> (node:net:672:12) {
  killed: false,
  code: 1,
  signal: null,
  cmd: 'yarn --json workspaces info',
  stdout: 'Unknown Syntax Error: Command not found; did you mean one of:\n' +
    '\n' +
    '  0. yarn workspaces list [--since] [-R,--recursive] [-v,--verbose] [--json]\n' +
    '  1. yarn workspaces focus [--json] [--production] [-A,--all] ...\n' +
    '\n' +
    'While running --json workspaces info\n',
  stderr: ''
}
```

A quick investigation brought me to the incorrect regexp in the `yarn-workspaces-list` utility, which I use.
`/1\./.test('3.1.0')` returns `true`, but classic yarn versions are only those starting with `1`.

Note, that I didn't test this solution properly.